### PR TITLE
Fix regressions in the Navigation 3 migration

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -146,7 +146,6 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
-    implementation(libs.androidx.material3.adaptive.navigation3)
 
     implementation(libs.androidx.compose.uiToolingPreview)
     debugImplementation(libs.androidx.compose.uiTooling)
@@ -156,7 +155,7 @@ dependencies {
     implementation(libs.coil.network.cache)
 
     implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
+    implementation(libs.hilt.lifecycle.viewmodel.compose)
     ksp(libs.androidx.hilt.compiler)
     ksp(libs.hilt.compiler)
 

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/navigation/DeeplinkRoute.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/navigation/DeeplinkRoute.kt
@@ -1,0 +1,7 @@
+package de.nilsdruyen.koncept.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeeplinkRoute(val rawDate: String, val rawDate2: String) : NavKey

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/navigation/KonceptAppState.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/navigation/KonceptAppState.kt
@@ -1,18 +1,14 @@
 package de.nilsdruyen.koncept.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
-import androidx.navigation.NavController
-import androidx.navigation.NavHostController
 import de.nilsdruyen.koncept.R
 import de.nilsdruyen.koncept.base.navigation.TopLevelRoute
 import de.nilsdruyen.koncept.design.system.Icon
 import de.nilsdruyen.koncept.design.system.KonceptIcons
 import de.nilsdruyen.koncept.dogs.ui.navigation.DogListRoute
 import de.nilsdruyen.koncept.dogs.ui.navigation.FavoritesRoute
-import de.nilsdruyen.koncept.domain.Logger.Companion.log
 
 @Composable
 fun rememberKonceptAppState(): KonceptAppState = remember { KonceptAppState() }
@@ -29,27 +25,14 @@ class KonceptAppState {
             selectedIcon = Icon.ImageVectorIcon(KonceptIcons.BreedList),
             unselectedIcon = Icon.ImageVectorIcon(KonceptIcons.BreedListFilled),
             iconTextId = R.string.breed_list_title,
+            testTag = "breed_list_graph",
         ),
         TopLevelRoute(
             route = FavoritesRoute,
             selectedIcon = Icon.ImageVectorIcon(KonceptIcons.Favorites),
             unselectedIcon = Icon.ImageVectorIcon(KonceptIcons.FavoritesFilled),
             iconTextId = R.string.favorites_title,
+            testTag = "favorites_graph",
         ),
     )
-}
-
-@Composable
-private fun NavigationTrackingSideEffect(navController: NavHostController) {
-    DisposableEffect(navController) {
-        val listener = NavController.OnDestinationChangedListener { _, destination, _ ->
-            log("${destination.route}")
-        }
-
-        navController.addOnDestinationChangedListener(listener)
-
-        onDispose {
-            navController.removeOnDestinationChangedListener(listener)
-        }
-    }
 }

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/navigation/KonceptAppState.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/navigation/KonceptAppState.kt
@@ -34,5 +34,12 @@ class KonceptAppState {
             iconTextId = R.string.favorites_title,
             testTag = "favorites_graph",
         ),
+        TopLevelRoute(
+            route = WebRoute,
+            selectedIcon = Icon.ImageVectorIcon(KonceptIcons.Web),
+            unselectedIcon = Icon.ImageVectorIcon(KonceptIcons.WebFilled),
+            iconTextId = R.string.web_title,
+            testTag = "web_graph",
+        ),
     )
 }

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/ui/DeeplinkSample.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/ui/DeeplinkSample.kt
@@ -7,17 +7,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import de.nilsdruyen.koncept.navigation.DeeplinkRoute
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
 /**
  * Deeplink sample
@@ -28,7 +30,12 @@ import javax.inject.Inject
  */
 
 @Composable
-fun DeeplinkSample(viewModel: DeeplinkViewModel = hiltViewModel()) {
+fun DeeplinkSample(route: DeeplinkRoute) {
+    val viewModel = hiltViewModel<DeeplinkViewModel, DeeplinkViewModel.Factory>(
+        creationCallback = { factory ->
+            factory.create(route)
+        },
+    )
     val date = viewModel.dateState.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -39,21 +46,28 @@ fun DeeplinkSample(viewModel: DeeplinkViewModel = hiltViewModel()) {
 private const val INPUT_DATE = "uuuu-MM-dd'T'HH:mm:ss[.SSSX][Z][ZZZZZ]"
 internal val inputFormatter = DateTimeFormatter.ofPattern(INPUT_DATE)
 
-@HiltViewModel
-class DeeplinkViewModel @Inject constructor(savedStateHandle: SavedStateHandle) : ViewModel() {
+@HiltViewModel(assistedFactory = DeeplinkViewModel.Factory::class)
+class DeeplinkViewModel @AssistedInject constructor(@Assisted route: DeeplinkRoute) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(route: DeeplinkRoute): DeeplinkViewModel
+    }
 
     val dateState = MutableStateFlow("")
 
     init {
-        val rawDate = savedStateHandle.get<String>("rawDate") ?: "empty"
-        val rawDate2 = savedStateHandle.get<String>("rawDate2") ?: "empty"
+        val rawDate = route.rawDate.ifEmpty { "empty" }
+        val rawDate2 = route.rawDate2.ifEmpty { "empty" }
 
         dateState.value = "$rawDate - $rawDate2"
 
-        viewModelScope.launch {
-            delay(2000)
-            val date = OffsetDateTime.parse(rawDate2, inputFormatter)
-            dateState.value = "$rawDate - ${date.month.name}"
+        if (route.rawDate2.isNotEmpty()) {
+            viewModelScope.launch {
+                delay(2000)
+                val date = OffsetDateTime.parse(route.rawDate2, inputFormatter)
+                dateState.value = "$rawDate - ${date.month.name}"
+            }
         }
     }
 }

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/ui/DeeplinkSample.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/ui/DeeplinkSample.kt
@@ -30,12 +30,14 @@ import java.time.format.DateTimeFormatter
  */
 
 @Composable
-fun DeeplinkSample(route: DeeplinkRoute) {
-    val viewModel = hiltViewModel<DeeplinkViewModel, DeeplinkViewModel.Factory>(
+fun DeeplinkSample(
+    route: DeeplinkRoute,
+    viewModel: DeeplinkViewModel = hiltViewModel<DeeplinkViewModel, DeeplinkViewModel.Factory>(
         creationCallback = { factory ->
             factory.create(route)
         },
-    )
+    ),
+) {
     val date = viewModel.dateState.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/ui/MainActivity.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package de.nilsdruyen.koncept.ui
 
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import dagger.hilt.android.AndroidEntryPoint
 import de.nilsdruyen.koncept.design.system.KonceptTheme
+import de.nilsdruyen.koncept.navigation.DeeplinkRoute
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -21,6 +23,8 @@ class MainActivity : ComponentActivity() {
         installSplashScreen().setKeepOnScreenCondition { !isDone.value }
         super.onCreate(savedInstanceState)
 
+        val deeplink = intent?.data?.toDeeplinkRoute()
+
         setContent {
             LaunchedEffect(Unit) {
                 // sync some stuff that is needed
@@ -28,8 +32,15 @@ class MainActivity : ComponentActivity() {
             }
 
             KonceptTheme {
-                KonceptApp()
+                KonceptApp(deeplink = deeplink)
             }
         }
     }
+}
+
+private fun Uri.toDeeplinkRoute(): DeeplinkRoute? {
+    if (scheme != "koncept" || host != "deeplink") return null
+    val rawDate = pathSegments.firstOrNull() ?: return null
+
+    return DeeplinkRoute(rawDate = rawDate, rawDate2 = getQueryParameter("rawDate2").orEmpty())
 }

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/ui/MainActivity.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/ui/MainActivity.kt
@@ -40,7 +40,8 @@ class MainActivity : ComponentActivity() {
 
 private fun Uri.toDeeplinkRoute(): DeeplinkRoute? {
     if (scheme != "koncept" || host != "deeplink") return null
-    val rawDate = pathSegments.firstOrNull() ?: return null
 
-    return DeeplinkRoute(rawDate = rawDate, rawDate2 = getQueryParameter("rawDate2").orEmpty())
+    return pathSegments.firstOrNull()?.let { rawDate ->
+        DeeplinkRoute(rawDate = rawDate, rawDate2 = getQueryParameter("rawDate2").orEmpty())
+    }
 }

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/ui/Navigation.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/ui/Navigation.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -32,9 +31,6 @@ import de.nilsdruyen.koncept.dogs.ui.navigation.DogListRoute
 import de.nilsdruyen.koncept.dogs.ui.navigation.dogRoutes
 import de.nilsdruyen.koncept.navigation.rememberKonceptAppState
 
-@OptIn(
-    ExperimentalComposeUiApi::class,
-)
 @Composable
 fun KonceptApp() {
     val navigator = rememberNavigator(DogListRoute)
@@ -46,18 +42,21 @@ fun KonceptApp() {
 @Composable
 fun MainBottomBarScreen(navigator: Navigator, sharedTransitionScope: SharedTransitionScope) {
     val state = rememberKonceptAppState()
+    val currentDestination = navigator.backStack.last()
+    val isTopLevelDestination = state.topLevelDestinations.any { it.route == currentDestination }
 
     Scaffold(
-        modifier = Modifier,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
-            KonceptBottomBar(
-                destinations = state.topLevelDestinations,
-                onNavigateToDestination = {
-                    navigator.goTo(it)
-                },
-                currentDestination = navigator.backStack.last(),
-            )
+            if (isTopLevelDestination) {
+                KonceptBottomBar(
+                    destinations = state.topLevelDestinations,
+                    onNavigateToDestination = {
+                        navigator.goToTopLevel(it)
+                    },
+                    currentDestination = currentDestination,
+                )
+            }
         },
     ) { padding ->
         NavDisplay(
@@ -81,7 +80,7 @@ fun MainBottomBarScreen(navigator: Navigator, sharedTransitionScope: SharedTrans
 private fun KonceptBottomBar(
     destinations: List<TopLevelRoute>,
     onNavigateToDestination: (NavKey) -> Unit,
-    currentDestination: NavKey?,
+    currentDestination: NavKey,
 ) {
     NavigationBar {
         destinations.forEach { item ->
@@ -107,7 +106,7 @@ private fun KonceptBottomBar(
                 label = {
                     Text(text = stringResource(id = item.iconTextId))
                 },
-                modifier = Modifier.testTag(item.route.toString()),
+                modifier = Modifier.testTag(item.testTag),
             )
         }
     }

--- a/app/src/main/kotlin/de/nilsdruyen/koncept/ui/Navigation.kt
+++ b/app/src/main/kotlin/de/nilsdruyen/koncept/ui/Navigation.kt
@@ -29,11 +29,13 @@ import de.nilsdruyen.koncept.base.navigation.rememberNavigator
 import de.nilsdruyen.koncept.design.system.Icon
 import de.nilsdruyen.koncept.dogs.ui.navigation.DogListRoute
 import de.nilsdruyen.koncept.dogs.ui.navigation.dogRoutes
+import de.nilsdruyen.koncept.navigation.DeeplinkRoute
+import de.nilsdruyen.koncept.navigation.WebRoute
 import de.nilsdruyen.koncept.navigation.rememberKonceptAppState
 
 @Composable
-fun KonceptApp() {
-    val navigator = rememberNavigator(DogListRoute)
+fun KonceptApp(deeplink: NavKey? = null) {
+    val navigator = rememberNavigator(DogListRoute, extraDestinations = listOfNotNull(deeplink))
     SharedTransitionLayout {
         MainBottomBarScreen(navigator, this)
     }
@@ -71,6 +73,12 @@ fun MainBottomBarScreen(navigator: Navigator, sharedTransitionScope: SharedTrans
             ),
             entryProvider = entryProvider {
                 dogRoutes(navigator, sharedTransitionScope)
+                entry<WebRoute> {
+                    WebScreen()
+                }
+                entry<DeeplinkRoute> { key ->
+                    DeeplinkSample(route = key)
+                }
             },
         )
     }

--- a/base/base-navigation/base-navigation.gradle.kts
+++ b/base/base-navigation/base-navigation.gradle.kts
@@ -10,7 +10,7 @@ configure<LibraryExtension> {
 dependencies {
     implementation(projects.design.designSystem)
 
-    api(libs.hilt.navigation.compose)
+    api(libs.hilt.lifecycle.viewmodel.compose)
 
     api(libs.androidx.navigation3.runtime)
     api(libs.androidx.navigation3.ui)

--- a/base/base-navigation/src/main/kotlin/de/nilsdruyen/koncept/base/navigation/Navigator.kt
+++ b/base/base-navigation/src/main/kotlin/de/nilsdruyen/koncept/base/navigation/Navigator.kt
@@ -6,22 +6,37 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 
-class Navigator(val backStack: NavBackStack<NavKey>) {
+class Navigator(val backStack: NavBackStack<NavKey>, private val startDestination: NavKey) {
 
     fun goTo(destination: NavKey) {
         backStack.add(destination)
     }
 
+    /**
+     * Switches to a top level destination: pops everything above the start destination and puts the
+     * selected destination on top. Reselecting the current destination is a no-op, so tab taps never
+     * stack duplicates and back always returns to the start destination.
+     */
+    fun goToTopLevel(destination: NavKey) {
+        if (backStack.last() == destination) return
+        backStack.removeAll { it != startDestination }
+        if (destination != startDestination) {
+            backStack.add(destination)
+        }
+    }
+
     fun goBack() {
-        backStack.removeLastOrNull()
+        if (backStack.size > 1) {
+            backStack.removeLastOrNull()
+        }
     }
 }
 
 @Composable
-fun rememberNavigator(startDestination: NavKey): Navigator {
-    val backStack = rememberNavBackStack(startDestination)
+fun rememberNavigator(startDestination: NavKey, extraDestinations: List<NavKey> = emptyList()): Navigator {
+    val backStack = rememberNavBackStack(startDestination, *extraDestinations.toTypedArray())
 
     return remember {
-        Navigator(backStack = backStack)
+        Navigator(backStack = backStack, startDestination = startDestination)
     }
 }

--- a/base/base-navigation/src/main/kotlin/de/nilsdruyen/koncept/base/navigation/TopLevelRoute.kt
+++ b/base/base-navigation/src/main/kotlin/de/nilsdruyen/koncept/base/navigation/TopLevelRoute.kt
@@ -3,4 +3,10 @@ package de.nilsdruyen.koncept.base.navigation
 import androidx.navigation3.runtime.NavKey
 import de.nilsdruyen.koncept.design.system.Icon
 
-data class TopLevelRoute(val route: NavKey, val selectedIcon: Icon, val unselectedIcon: Icon, val iconTextId: Int)
+data class TopLevelRoute(
+    val route: NavKey,
+    val selectedIcon: Icon,
+    val unselectedIcon: Icon,
+    val iconTextId: Int,
+    val testTag: String,
+)

--- a/features/dogs/dogs-ui/src/main/kotlin/de/nilsdruyen/koncept/dogs/ui/navigation/DogEntryProvider.kt
+++ b/features/dogs/dogs-ui/src/main/kotlin/de/nilsdruyen/koncept/dogs/ui/navigation/DogEntryProvider.kt
@@ -1,17 +1,29 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class)
+
 package de.nilsdruyen.koncept.dogs.ui.navigation
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import de.nilsdruyen.koncept.base.navigation.Navigator
+import de.nilsdruyen.koncept.dogs.entity.BreedSortType
 import de.nilsdruyen.koncept.dogs.ui.detail.BreedDetailScreen
 import de.nilsdruyen.koncept.dogs.ui.detail.BreedDetailViewModel
 import de.nilsdruyen.koncept.dogs.ui.favorites.Favorites
 import de.nilsdruyen.koncept.dogs.ui.image.ImageDetailScreen
 import de.nilsdruyen.koncept.dogs.ui.list.DogListScreen
+import de.nilsdruyen.koncept.dogs.ui.list.components.DogListSortDialog
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -28,16 +40,28 @@ data class ImageRoute(val id: String) : NavKey
 
 fun EntryProviderScope<NavKey>.dogRoutes(navigator: Navigator, sharedTransitionScope: SharedTransitionScope) {
     entry<DogListRoute> {
-        val sortType = remember { mutableIntStateOf(1) }
+        var sortType by rememberSaveable { mutableIntStateOf(BreedSortType.Name.ordinal) }
+        var sortDialogType by rememberSaveable { mutableStateOf<BreedSortType?>(null) }
         DogListScreen(
-            sortTypeState = sortType.intValue,
+            sortTypeState = sortType,
             showDetail = { id ->
                 navigator.goTo(DogDetailRoute(id.value))
             },
             showSortDialog = { type ->
-                //                        onNavigate(BreedListSortDialogRoute.createRoute(BreedListRoute, type))
+                sortDialogType = type
             },
         )
+        sortDialogType?.let { selectedType ->
+            ModalBottomSheet(onDismissRequest = { sortDialogType = null }) {
+                DogListSortDialog(
+                    selectedType = selectedType,
+                    setResult = { type ->
+                        sortType = type.ordinal
+                        sortDialogType = null
+                    },
+                )
+            }
+        }
     }
     entry<DogDetailRoute> { key ->
         val viewModel = hiltViewModel<BreedDetailViewModel, BreedDetailViewModel.Factory>(
@@ -54,7 +78,15 @@ fun EntryProviderScope<NavKey>.dogRoutes(navigator: Navigator, sharedTransitionS
         )
     }
     entry<ImageRoute> { key ->
-        ImageDetailScreen(id = key.id)
+        with(sharedTransitionScope) {
+            ImageDetailScreen(
+                id = key.id,
+                imageModifier = Modifier.sharedElement(
+                    sharedTransitionScope.rememberSharedContentState(key = "image-${key.id}"),
+                    animatedVisibilityScope = LocalNavAnimatedContentScope.current,
+                ),
+            )
+        }
     }
     entry<FavoritesRoute> {
         Favorites(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ composeActivity = "1.13.0"
 composeBom = "2026.04.01"
 composeCompilerReportGenerator = "1.5.0"
 composeConstraintLayout = "1.1.1"
-composeNavigation = "2.9.7"
 coroutines = "1.10.2"
 detekt = "2.0.0-alpha.2"
 detektComposeRules = "0.5.7"
@@ -27,7 +26,7 @@ espresso = "3.7.0"
 gradleVersionsPlugin = "0.53.0"
 hilt = "2.59.2"
 hiltCompiler = "1.3.0"
-hiltNavigationCompose = "1.3.0"
+hiltLifecycleViewmodelCompose = "1.3.0"
 jUnitExt = "1.3.0"
 javaxInject = "1"
 junit4 = "4.13.2"
@@ -49,9 +48,8 @@ splashscreen = "1.2.0"
 turbine = "1.2.1"
 uiautomator = "2.3.0"
 versionCompare = "1.5.0"
-navigation3 = "1.0.0"
-material3AdaptiveNav3 = "1.3.0-alpha05"
-lifecycleViewmodelNav3 = "2.10.0"
+navigation3 = "1.1.4"
+lifecycleViewmodelNav3 = "2.11.0"
 
 [libraries]
 accompanist-placeholder = { module = "com.google.accompanist:accompanist-placeholder", version.ref = "accompanist" }
@@ -111,7 +109,7 @@ hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", ve
 hilt-android-test = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt" }
-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "hiltLifecycleViewmodelCompose" }
 javaxInject = { module = "javax.inject:javax.inject", version.ref = "javaxInject" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit5-api = { module = "org.junit.jupiter:junit-jupiter-api" }
@@ -125,7 +123,6 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-androi
 kotlinx-coroutines-playservices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-kover-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "koverPlugin" }
-kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 kotlinx-serial = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie" }
@@ -153,7 +150,6 @@ versionCompare = { module = "io.github.g00fy2:versioncompare", version.ref = "ve
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
-androidx-material3-adaptive-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "material3AdaptiveNav3" }
 
 [bundles]
 android-test = ["turbine", "kotlinx.coroutines.test"]


### PR DESCRIPTION
Review follow-up for the Navigation 3 migration (#465). A deep review against `develop` found several behaviors that were lost or silently changed in the migration; this PR restores them in three commits.

## 1. Top-level navigation semantics (`Navigator`, `Navigation.kt`)

The old bottom bar used `launchSingleTop` + `popUpTo(start) { saveState = true }` + `restoreState` and no-op'd on reselect. After the migration, every tab tap did a plain `backStack.add(...)`:

- re-tapping the current tab stacked a duplicate entry (fresh state + fresh ViewModel each time),
- alternating tabs grew the back stack without bound, and back replayed the whole tap history.

`Navigator.goToTopLevel` now pops to the start destination and puts the selected tab on top, and reselecting is a no-op. `goBack()` is guarded so the back stack can never empty out (`NavDisplay` throws on an empty stack). The bottom bar is also hidden again on non-top-level destinations — before the migration, detail/image screens rendered full screen above the scaffold. Note: per-tab state saving (`saveState`/`restoreState`) is *not* fully restored — that would need per-tab back stacks; tab content state resets on switch, which is a known limitation of this simple approach.

## 2. Lost features restored

- **Sort dialog**: the sort button was a no-op with commented-out code, and the hardcoded `mutableIntStateOf(1)` silently changed the default sort from `Name` (ordinal 0) to `LifeSpan` (ordinal 1). The dialog now opens as a `ModalBottomSheet` from the dog list entry (it no longer needs to be a navigation destination), and the default is `Name` again.
- **Image shared element**: `BreedDetailScreen` still tagged grid images with `sharedElement(key = "image-…")`, but `ImageDetailScreen` was called without the matching `imageModifier`, so the transition never ran. The `ImageRoute` entry applies it again via `LocalNavAnimatedContentScope`.
- **Web tab**: the third bottom-bar destination was dropped — `WebRoute` existed as a `NavKey` but had no entry and nothing navigated to it. It's registered again with `WebScreen`.
- **Deep link**: the `koncept://deeplink` intent filter in the manifest had no handler anymore (Nav3 has no built-in deep link support). `MainActivity` now parses the URI into a `DeeplinkRoute` placed on the initial back stack, and `DeeplinkViewModel` gets its arguments via assisted injection instead of `SavedStateHandle` nav args — same pattern as `BreedDetailViewModel`.
- **Instrumentation tests**: `MainActivityTest` asserts on tags `breed_list_graph` / `favorites_graph` / `web_graph`, but the bar used `route.toString()` (`"DogListRoute"`, …) and the web tab was gone. `TopLevelRoute` now carries an explicit `testTag`, so the existing tests pass unchanged.

## 3. Dependency cleanup

- `androidx.hilt:hilt-navigation-compose` → `androidx.hilt:hilt-lifecycle-viewmodel-compose`: the code already imports `hiltViewModel` from the new package (androidx.hilt 1.3.0 moved it there specifically to avoid the transitive Navigation 2 dependency); the old artifact only resolved transitively and dragged Nav2 back into every consumer. This also allowed deleting the dead Nav2-based `NavigationTrackingSideEffect`.
- Removed the unused `material3.adaptive:adaptive-navigation3` dependency and the orphaned `kotlinx-serialization-core` / `composeNavigation` catalog entries.
- Bumped `navigation3` 1.0.0 → 1.1.4 and `lifecycle-viewmodel-navigation3` 2.10.0 → 2.11.0 (current stables; the APIs in use are unchanged between these versions).

⚠️ No Android SDK was available in the working environment, so this was verified by static review against the Navigation 3 1.0/1.1 API surface, not by compilation — please let CI confirm the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n4aUqkjXL9fF2JC6HkoGp

---
_Generated by [Claude Code](https://claude.ai/code/session_015n4aUqkjXL9fF2JC6HkoGp)_