### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!--
+  Title format follows Conventional Commits, e.g.:
+  feat(auth): add OAuth2 login flow
+  fix(api): handle empty response body
+-->
+
+## Summary
+
+<!-- What does this PR do and why? 1–3 sentences. Link context if needed. -->
+
+## Type of Change
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code change without behavior change
+- [ ] `perf` — performance improvement
+- [ ] `docs` — documentation only
+- [ ] `test` — adding or updating tests
+- [ ] `build` / `ci` — build system or CI changes
+- [ ] `chore` — maintenance, dependencies, tooling
+
+## Related Issues
+
+<!-- e.g. Closes #123, Relates to #456 -->
+
+## Changes
+
+<!-- Bullet list of the relevant changes. Keep it reviewable. -->
+
+-
+
+## How to Test
+
+<!-- Steps a reviewer can follow to verify the change locally. -->
+
+1.
+
+## Screenshots / Recordings
+
+<!-- UI changes only — before/after if applicable. Delete section otherwise. -->
+
+## Checklist
+
+- [ ] Branch targets the correct base (`develop` for features, `main` only for release/hotfix)
+- [ ] Commits follow Conventional Commits
+- [ ] Code follows project coding standards (SOLID, clean architecture boundaries respected)
+- [ ] Self-review performed
+- [ ] Tests added/updated and passing locally
+- [ ] Documentation updated (README, ADRs, comments) where necessary
+- [ ] No secrets, credentials, or debug leftovers in the diff
+- [ ] Breaking changes documented (`BREAKING CHANGE:` footer in commit if applicable)
+
+## Notes for Reviewers
+
+<!-- Anything reviewers should focus on, known trade-offs, follow-up work. -->


### PR DESCRIPTION
## Summary

Adds a `.github/PULL_REQUEST_TEMPLATE.md` so new PRs get a consistent structure (summary, type of change, related issues, changes, test steps, checklist).

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code change without behavior change
- [ ] `perf` — performance improvement
- [ ] `docs` — documentation only
- [ ] `test` — adding or updating tests
- [ ] `build` / `ci` — build system or CI changes
- [x] `chore` — maintenance, dependencies, tooling

## Related Issues

N/A

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Open a new PR in this repository and confirm the template is prefilled.

## Checklist

- [x] Branch targets the correct base (`develop` for features, `main` only for release/hotfix)
- [x] Commits follow Conventional Commits
- [x] Self-review performed
- [ ] Tests added/updated and passing locally (not applicable — docs/template only)
- [x] No secrets, credentials, or debug leftovers in the diff


---
_Generated by [Claude Code](https://claude.ai/code/session_01QzskmEji2oQn8Xza9Ud7pV)_